### PR TITLE
linguist (github) syntax highlighting for .bt files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bt linguist-language=c


### PR DESCRIPTION
010 Binary Templates are (almost) valid C, this file will tell GitHub's syntax highlighter, linguist that the files should follow c/c++ syntax highlighting rules.